### PR TITLE
Add support for using tls connection

### DIFF
--- a/changelog/4.added.md
+++ b/changelog/4.added.md
@@ -1,0 +1,1 @@
+Added support for specifying TLS connection parameters to the execution module

--- a/src/saltext/mysql/modules/mysql.py
+++ b/src/saltext/mysql/modules/mysql.py
@@ -433,6 +433,7 @@ def _connect(**kwargs):
     _connarg("connection_unix_socket", "unix_socket", get_opts)
     _connarg("connection_default_file", "read_default_file", get_opts)
     _connarg("connection_default_group", "read_default_group", get_opts)
+    _connarg("connection_ssl", "ssl", get_opts)
     # MySQLdb states that this is required for charset usage
     # but in fact it's more than it's internally activated
     # when charset is used, activating use_unicode here would


### PR DESCRIPTION
I've notices that it isn't possible to setup a ssl connection with the module of mysql. With this change the parameter `ssl` can be set. This enables users to set a minion config with the following config:

```
mysql.ssl:
  ca: /path/to/ca.pem
```

This will pass the `ssl` parameter to the underlying library with the dictionary as supported by [MySQLdb](https://github.com/farcepest/MySQLdb1/blob/master/MySQLdb/connections.py#L133) and [PyMySQL](https://github.com/PyMySQL/PyMySQL/blob/main/pymysql/connections.py#L131)