### PR TITLE
fix presence detection when using mysql_cache

### DIFF
--- a/changelog/9.fixed.md
+++ b/changelog/9.fixed.md
@@ -1,0 +1,1 @@
+Fixed `mysql_cache.list` not listing nested banks, thereby fixed presence detection when using the `mysql_cache` module

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,7 +79,10 @@ rst_prolog = """
 
 # -- General configuration ---------------------------------------------------
 
-linkcheck_ignore = [r"http://localhost:\d+"]
+linkcheck_ignore = [
+    r"http://localhost:\d+",
+    "https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html",
+]
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/src/saltext/mysql/states/mysql_query.py
+++ b/src/saltext/mysql/states/mysql_query.py
@@ -94,7 +94,7 @@ def run_file(
 
     client_flags:
         A list of client flags to pass to the MySQL connection.
-        https://dev.mysql.com/doc/internals/en/capability-flags.html
+        https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html
 
     """
     ret = {
@@ -267,7 +267,7 @@ def run(
 
     client_flags:
         A list of client flags to pass to the MySQL connection.
-        https://dev.mysql.com/doc/internals/en/capability-flags.html
+        https://dev.mysql.com/doc/dev/mysql-server/latest/group__group__cs__capabilities__flags.html
 
     """
     ret = {

--- a/tests/functional/cache/helpers.py
+++ b/tests/functional/cache/helpers.py
@@ -228,3 +228,27 @@ def run_common_cache_tests(subtests, cache):
         assert cache_result == fetch_result
         assert fetch_result == expected_result
         assert cache_result == fetch_result == expected_result
+
+    with subtests.test("hierarchical listing should work correctly"):
+        # Store some test data
+        cache.store(bank="root", key="file1", data="data1")
+        cache.store(bank="root/sub/dir", key="foo", data="data2")
+        cache.store(bank="root/sub/dir", key="bar", data="data3")
+        cache.store(bank="root/another_sub/dir", key="baz", data="data4")
+
+        # List root - should get direct entries and first segments of sub-paths
+        root_list = cache.list("root")
+        assert set(root_list) == {"file1", "sub", "another_sub"}
+
+        # List a sub-path
+        sub_list = cache.list("root/sub")
+        assert set(sub_list) == {"dir"}
+
+        # List a full path
+        dir_list = cache.list("root/sub/dir")
+        assert set(dir_list) == {"foo", "bar"}
+
+        # Clean up test data
+        cache.flush(bank="root", key=None)
+        cache.flush(bank="root/sub/dir", key=None)
+        cache.flush(bank="root/another_sub/dir", key=None)


### PR DESCRIPTION
### What does this PR do?
This fixes presence detection when using `mysql_cache`.
Add functional subtest for the changes.

### What issues does this PR fix or reference?
Fixes: #9 

### Previous Behavior
```sh
$ salt-run  manage.present
$
```

### New Behavior
```sh
$ salt-run  manage.present
- minion1
- minion2
$
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
