### PR TITLE
Fix "grant" revokes issues

### DIFF
--- a/changelog/18.fixed.md
+++ b/changelog/18.fixed.md
@@ -1,0 +1,1 @@
+Fixed uneeded escape of "_". MySQL identifiers documentation does not mention it needing escape in the changed circunstances.

--- a/changelog/21.fixed.md
+++ b/changelog/21.fixed.md
@@ -1,0 +1,1 @@
+Fixed an issue where `mysql_grants.absent` was not passing the escape param correctly to the `mysql.grant_revoke` on mysql module.

--- a/src/saltext/mysql/modules/mysql.py
+++ b/src/saltext/mysql/modules/mysql.py
@@ -230,7 +230,7 @@ used with {'myval': 'some user input'}
 So far so good. But this cannot be used for identifier escapes. Identifiers
 are database names, table names and column names. Theses names are not values
 and do not follow the same escape rules (see quote_identifier function for
-details on `_ and % escape policies on identifiers). Using value escaping on
+details on escape policies on identifiers). Using value escaping on
 identifier could fool the SQL engine (badly escaping quotes and not doubling
 ` characters. So for identifiers a call to quote_identifier should be done and
 theses identifiers should then be added in strings with format, but without
@@ -256,7 +256,7 @@ The MySQL way of writing this name is:
 
 value                         : 'f_o%o`b\'a"r' (managed by MySQLdb)
 identifier                    : `f_o%o``b'a"r`
-db identifier in general GRANT: `f\_o\%o``b'a"r`
+db identifier in general GRANT: `f_o\%o``b'a"r`
 db identifier in table GRANT  : `f_o%o``b'a"r`
 in mySQLdb, query with args   : `f_o%%o``b'a"r` (as identifier)
 in mySQLdb, query without args: `f_o%o``b'a"r` (as identifier)
@@ -694,7 +694,7 @@ def _resolve_grant_aliases(grants, server_version):
     return resolved_tokens
 
 
-def quote_identifier(identifier, for_grants=False):
+def quote_identifier(identifier):
     r"""
     Return an identifier name (column, table, database, etc) escaped for MySQL
 
@@ -703,22 +703,13 @@ def quote_identifier(identifier, for_grants=False):
 
     :param identifier: the table, column or database identifier
 
-    :param for_grants: is False by default, when using database names on grant
-     queries you should set it to True to also escape "_" and "%" characters as
-     requested by MySQL. Note that theses characters should only be escaped when
-     requesting grants on the database level (`my\_\%db`.*) but not for table
-     level grants (`my_%db`.`foo`)
-
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' mysql.quote_identifier 'foo`bar'
     """
-    if for_grants:
-        return "`" + identifier.replace("`", "``").replace("_", r"\_").replace("%", r"%%") + "`"
-    else:
-        return "`" + identifier.replace("`", "``").replace("%", "%%") + "`"
+    return "`" + identifier.replace("`", "``").replace("%", r"%%") + "`"
 
 
 def _execute(cur, qry, args=None):
@@ -2365,9 +2356,9 @@ def __grant_generate(
 
     if escape:
         if dbc != "*":
-            # _ and % are authorized on GRANT queries and should get escaped
+            # % is authorized on GRANT queries and should get escaped
             # on the db name, but only if not requesting a table level grant
-            dbc = quote_identifier(dbc, for_grants=table == "*")
+            dbc = quote_identifier(dbc)
         if table != "*":
             table = quote_identifier(table)
     # identifiers cannot be used as values, and same thing for grants
@@ -2601,9 +2592,9 @@ def grant_revoke(
     dbc = db_part[0]
     table = db_part[2]
     if dbc != "*":
-        # _ and % are authorized on GRANT queries and should get escaped
+        # % is authorized on GRANT queries and should get escaped
         # on the db name, but only if not requesting a table level grant
-        s_database = quote_identifier(dbc, for_grants=table == "*")
+        s_database = quote_identifier(dbc)
     else:
         # add revoke for *.*
         # before the modification query send to mysql will looks like

--- a/src/saltext/mysql/modules/mysql.py
+++ b/src/saltext/mysql/modules/mysql.py
@@ -2591,17 +2591,18 @@ def grant_revoke(
     db_part = database.rpartition(".")
     dbc = db_part[0]
     table = db_part[2]
-    if dbc != "*":
-        # % is authorized on GRANT queries and should get escaped
-        # on the db name, but only if not requesting a table level grant
-        s_database = quote_identifier(dbc)
-    else:
+    if escape:
+        if dbc != "*":
+            # % is authorized on GRANT queries and should get escaped
+            # on the db name, but only if not requesting a table level grant
+            s_database = quote_identifier(dbc)
+        if table != "*":
+            table = quote_identifier(table)
+    if dbc == "*":
         # add revoke for *.*
         # before the modification query send to mysql will looks like
         # REVOKE SELECT ON `*`.* FROM %(user)s@%(host)s
         s_database = dbc
-    if table != "*":
-        table = quote_identifier(table)
     # identifiers cannot be used as values, same thing for grants
     qry = f"REVOKE {grant} ON {s_database}.{table} FROM %(user)s@%(host)s;"
     args = {}

--- a/src/saltext/mysql/states/mysql_grants.py
+++ b/src/saltext/mysql/states/mysql_grants.py
@@ -245,7 +245,7 @@ def absent(
             ret["comment"] = f"MySQL grant {name} is set to be revoked"
             return ret
         if __salt__["mysql.grant_revoke"](
-            grant, database, user, host, grant_option, **connection_args
+            grant, database, user, host, grant_option, escape, **connection_args
         ):
             ret["comment"] = "Grant {} on {} for {}@{} has been revoked".format(
                 grant, database, user, host

--- a/tests/unit/modules/test_mysql.py
+++ b/tests/unit/modules/test_mysql.py
@@ -659,19 +659,54 @@ def test_grant_add():
     )
 
 
-@pytest.mark.skipif(True, reason="TODO: Mock up user_grants()")
 def test_grant_revoke():
     """
     Test grant revoke in mysql exec module
     """
-    _test_call(
-        mysql.grant_revoke,
-        "",
-        "SELECT,INSERT,UPDATE",
-        "database.*",
-        "frank",
-        "localhost",
-    )
+    mock_grants = [
+        "GRANT USAGE ON *.* TO 'testuser'@'%'",
+        "GRANT SELECT, INSERT, UPDATE ON database_1.testtableone TO 'testuser'@'%'",
+        "GRANT DELETE ON resitrict%ed.* TO 'testuser'@'%'",
+    ]
+
+    connect_mock = MagicMock()
+    with patch.object(mysql, "_connect", connect_mock):
+        with patch.object(mysql, "version", return_value="8.0.10"):
+            with patch.object(mysql, "user_grants", return_value=mock_grants):
+                with patch.dict(mysql.__salt__, {"config.option": MagicMock()}):
+                    mysql.grant_revoke(
+                        grant="SELECT, INSERT, UPDATE",
+                        database="database_1.testtableone",
+                        user="testuser",
+                        host="%",
+                    )
+
+                    mysql.grant_revoke(
+                        grant="DELETE", database="resitrict%ed.*", user="testuser", host="%"
+                    )
+
+                    calls = [
+                        call()
+                        .cursor()
+                        .execute(
+                            "REVOKE SELECT, INSERT, UPDATE ON `database_1`.`testtableone` FROM "
+                            "%(user)s@%(host)s;",
+                            {"host": "%", "user": "testuser"},
+                        ),
+                        call()
+                        .cursor()
+                        .execute(
+                            "REVOKE DELETE ON `resitrict%%ed`.* FROM %(user)s@%(host)s;",
+                            {"host": "%", "user": "testuser"},
+                        ),
+                    ]
+                    connect_mock.assert_has_calls(calls, any_order=True)
+
+            with patch.object(mysql, "grant_exists", return_value=False):
+                revoke = mysql.grant_revoke(
+                    grant="USAGE", database="*.*", user="testuser", host="%"
+                )
+                assert revoke
 
 
 def test_processlist():


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes
- https://github.com/salt-extensions/saltext-mysql/issues/18
- https://github.com/salt-extensions/saltext-mysql/issues/21

### Previous Behavior
- Revokes were failing
```
Did not write failed 'REVOKE SELECT ON `underscore\_db`.*`
```
- "escape" param was not being passed to `grants_revoke`

### New Behavior
- Revoke works as expected
```
Grant SELECT on underscore_db for testuser@172.%' has been revoked
```
- "escape" param is being passed along

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [ ] Docs
- [X] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [X] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
